### PR TITLE
Saving set of rules into preset files

### DIFF
--- a/AddPrefixRule/AddPrefix.cs
+++ b/AddPrefixRule/AddPrefix.cs
@@ -25,9 +25,6 @@ namespace AddPrefixRule
 			return (Prefix + " " + inp);
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/AddSuffixRule/AddSuffix.cs
+++ b/AddSuffixRule/AddSuffix.cs
@@ -26,9 +26,6 @@ namespace AddSuffixRule
 			return origin.Insert(index, (" " + Suffix));
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/ChangeFileExtensionRule/ChangeFileExtension.cs
+++ b/ChangeFileExtensionRule/ChangeFileExtension.cs
@@ -24,9 +24,6 @@ namespace ChangeFileExtensionRule
 			return origin.Remove(index + 1) + NewExtension;
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/Contract/IRule.cs
+++ b/Contract/IRule.cs
@@ -17,14 +17,8 @@
 
         public string Parse { set { } }
 
-        public string Rename(string origin, int fileIndex)
-        {
-			return origin;
-        }
+        public string Rename(string origin, int fileIndex) => origin;
 
-        public object Clone()
-		{
-			return MemberwiseClone();
-		}
+        public object Clone() => MemberwiseClone();
 	}
 }

--- a/Contract/IRule.cs
+++ b/Contract/IRule.cs
@@ -2,10 +2,29 @@
 {
 	public interface IRule
 	{
-		string Name { get; }
-		string Config { get; }
-		string Parse { set; }
+        string Name { get; }
+        string Config { get; }
+        string Parse { set; }
 		string Rename(string origin, int fileIndex);
 		object Clone();
+	}
+
+    // JSON Deserialize Template
+    public readonly struct RuleDeserializeTemplate : IRule
+	{
+		public string Name { get; init; }
+		public string Config { get; init; }
+
+        public string Parse { set { } }
+
+        public string Rename(string origin, int fileIndex)
+        {
+			return origin;
+        }
+
+        public object Clone()
+		{
+			return MemberwiseClone();
+		}
 	}
 }

--- a/FinalProject/MainWindow.xaml.cs
+++ b/FinalProject/MainWindow.xaml.cs
@@ -5,9 +5,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
 using Microsoft.WindowsAPICodePack.Dialogs;
-using System;
 using System.Text;
-using System.Reflection;
 
 namespace FinalProject
 {
@@ -62,24 +60,8 @@ namespace FinalProject
 
 
 		// ========================================
-		// ========== Build-in functions ==========
+		// =============== Utilities ==============
 		// ========================================
-
-		// Read rule file
-		[Obsolete("Overshadowed by PresetProcessor's ReadPresetFile method.")]
-		private List<string> RuleFileReader(string ruleFilePath)
-		{
-			try
-			{
-				return new List<string>(File.ReadAllLines(ruleFilePath));
-			}
-			catch (Exception e)
-			{
-				MessageBox.Show("Rule file not found", e.ToString());
-				return null;
-			}
-		}
-
 		
 		// Update file preview list (intergrated inside UpdateFactory)
 		private void UpdateFilePreviewList(bool forced = false)
@@ -265,6 +247,7 @@ namespace FinalProject
 			ruleConfigTextBox.Text = selectedRuleFromAvailable.RuleConfig;
 		}
 
+		
 		// Add selected rule to rule preview list
 		private void addRuleButton_Click(object sender, RoutedEventArgs e)
 		{

--- a/FinalProject/MainWindow.xaml.cs
+++ b/FinalProject/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using System;
 using System.Text;
+using System.Reflection;
 
 namespace FinalProject
 {
@@ -59,12 +60,13 @@ namespace FinalProject
 		}
 
 
-		
+
 		// ========================================
 		// ========== Build-in functions ==========
 		// ========================================
-		
+
 		// Read rule file
+		[Obsolete("Overshadowed by PresetProcessor's ReadPresetFile method.")]
 		private List<string> RuleFileReader(string ruleFilePath)
 		{
 			try
@@ -214,43 +216,43 @@ namespace FinalProject
 		// Select preset file
 		private void selectRulePresetButton_Click(object sender, RoutedEventArgs e)
 		{
-			var dialog = new OpenFileDialog();
-			dialog.Filter = "Rule Files (*.txt; *.json)|*.txt;*.json|All files (*.*)|*.*";
+			var dialog = new OpenFileDialog
+			{
+                Title = "Open Rule Preset File...",
+                Filter = "Rule Files (*.txt; *.json)|*.txt;*.json|All files (*.*)|*.*"
+        };
 
 			if (dialog.ShowDialog() == true)
 			{
-				var info = new FileInfo(dialog.FileName);
+                var info = new FileInfo(dialog.FileName);
 
-				// Setup factory
-				var fileContent = RuleFileReader(dialog.FileName);
+                List<IRule> newRuleList = PresetProcessor.ReadPresetFile(dialog, f, out bool success);
 
-				List<IRule> newRuleList = new List<IRule>();
-				foreach (string line in fileContent)
+				if (success)
 				{
-					newRuleList.Add(f.StringToIRuleConverter(line));
-				}
-				f.RuleList = newRuleList;
+                    f.RuleList = newRuleList;
 
-			// Display the rule file name to TextBox
-			ruleFileName.Text = info.Name;
+                    // Display the rule file name to TextBox
+                    ruleFileName.Text = info.Name;
 
-				//Update rule preview list
-				_selectedRules.Clear();
+                    //Update rule preview list
+                    _selectedRules.Clear();
 
-				foreach (var r in f.RuleList)
-				{
-					if (r == null) continue;
+                    foreach (var r in f.RuleList)
+                    {
+                        if (r == null) continue;
 
-					var item = new
-					{
-						RuleName = r.Name,
-						RuleConfig = r.Config
-					};
-					_selectedRules.Add(item);
-				}
-				rulePreviewListView.ItemsSource = _selectedRules;
+                        var item = new
+                        {
+                            RuleName = r.Name,
+                            RuleConfig = r.Config
+                        };
+                        _selectedRules.Add(item);
+                    }
+                    rulePreviewListView.ItemsSource = _selectedRules;
 
-				UpdateFactory();
+                    UpdateFactory();
+                }
 			}
 		}
 
@@ -326,13 +328,32 @@ namespace FinalProject
 			}
 		}
 
-		// === TODO ===
 		// Save the current list of rules in _selectedRules to a file
 		private void saveRulePresetButton_Click(object sender, RoutedEventArgs e)
 		{
-			return;
+			var dialog = new SaveFileDialog
+			{
+				Title = "Save Rule Preset File...",
+				Filter = "Raw Preset File (*.txt)|*.txt|JSON Preset File (*.json)|*.json"
+			};
+
+			// If a preset file has already been loaded before, use its name as default file name for saving.
+			if (ruleFileName.Text != "")
+			{
+				dialog.FileName = ruleFileName.Text;
+			}
+
+            if (dialog.ShowDialog() == true)
+            {
+                bool success = PresetProcessor.WritePresetFile(dialog, f);
+
+				if (success)
+				{
+					MessageBox.Show($"Successfully saved preset to path:\n{dialog.FileName}", "Success");
+				}
+            }
+            return;
 		}
-		// ============
 
 
 		// Open dialog to edit rule config

--- a/FinalProject/MainWindow.xaml.cs
+++ b/FinalProject/MainWindow.xaml.cs
@@ -215,6 +215,7 @@ namespace FinalProject
 		private void selectRulePresetButton_Click(object sender, RoutedEventArgs e)
 		{
 			var dialog = new OpenFileDialog();
+			dialog.Filter = "Rule Files (*.txt; *.json)|*.txt;*.json|All files (*.*)|*.*";
 
 			if (dialog.ShowDialog() == true)
 			{

--- a/FinalProject/PresetProcessor.cs
+++ b/FinalProject/PresetProcessor.cs
@@ -14,7 +14,7 @@ namespace FinalProject
     {
         public const int NOT_FOUND_LIMIT = 8;
 
-        public static List<IRule> ReadPresetFile(OpenFileDialog target, RuleFactory ruleFactory, out bool success)
+		public static List<IRule> ReadPresetFile(OpenFileDialog target, RuleFactory ruleFactory, out bool success)
         {
             success = false;
             string fileName = target.FileName;
@@ -25,7 +25,8 @@ namespace FinalProject
 
             List<IRule> newRuleList = new List<IRule>();
             List<string> notFoundList = new List<string>();
-            // Load rule preset files with the following file types:
+			
+            // Load rule preset files
             switch (extension)
             {
                 // JSON RULE PRESET FILE
@@ -37,11 +38,12 @@ namespace FinalProject
 
                         if (deserializedRules != null)
                         {
-                            //newRuleList = ruleList;
-
                             foreach (RuleDeserializeTemplate ruleTemplate in deserializedRules)
                             {
-                                string rawRule = $"{ruleTemplate.Name} {ruleTemplate.Config}";
+                                string configJsonPatch = ruleTemplate.Config;
+
+
+								string rawRule = $"{ruleTemplate.Name} {ruleTemplate.Config}";
                                 Debug.WriteLine(rawRule);
                                 IRule? rule = ruleFactory.StringToIRuleConverter(rawRule, out bool found);
                                 if (rule != null)
@@ -54,17 +56,16 @@ namespace FinalProject
 
                             success = true;
                         }
-                        /*
-                        else
-                        {
-                            MessageBox.Show("Deserialized list is null.");
-                        }
-                        */
+                        
+                        else { MessageBox.Show("Deserialized list is null."); }
                     }
                     catch (Exception e)
                     {
-                        MessageBox.Show($"Unable to deserialize JSON Preset.\n\n{e.Message}", e.ToString(), MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
+                        MessageBox.Show($"Unable to deserialize JSON Preset.\n\n{e.Message}",
+							            e.ToString(),               // Caption
+							            MessageBoxButton.OK,        // Button
+							            MessageBoxImage.Error);     // Icon
+					}
                     break;
 
                 // RAW RULE PRESET FILE
@@ -77,7 +78,10 @@ namespace FinalProject
                     }
                     catch (Exception e)
                     {
-                        MessageBox.Show("Rule file not found", e.ToString(), MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show("Rule file not found",
+                                        e.ToString(),
+                                        MessageBoxButton.OK,
+                                        MessageBoxImage.Error);
                     }
 
                     foreach (string line in fileContent)
@@ -93,13 +97,17 @@ namespace FinalProject
                     break;
 
                 default:
-                    MessageBox.Show($"Unsupported file type ({extension})", "Rule Preset Reader", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show($"Unsupported file type ({extension})",
+                                    "Rule Preset Reader",
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Warning);
                     break;
             }
 
             if (notFoundList.Count > 0)
             {
                 string overflowNotice = "";
+				
                 int overflow = notFoundList.Count - NOT_FOUND_LIMIT;
                 if (overflow > 0)
                 {
@@ -107,7 +115,10 @@ namespace FinalProject
                     notFoundList.RemoveRange(NOT_FOUND_LIMIT - 1, overflow);
                 }
                 
-                MessageBox.Show($"Unable to load the following rules:\n\n- {string.Join("\n- ", notFoundList)}{overflowNotice}", "StringToIRuleConverter", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                MessageBox.Show($"Unable to load the following rules:\n\n- {string.Join("\n- ", notFoundList)}{overflowNotice}",
+                    "StringToIRuleConverter",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Exclamation);
             }
 
             return newRuleList;
@@ -122,12 +133,12 @@ namespace FinalProject
             if (extension != "") extension = extension.Substring(1);
 
             string result = "";
-            // Save rule preset file in the following file types:
+            // Save rule preset file
             switch (extension)
             {
                 case "json":
-                    result = ruleFactory.IRuleToStringConverter(true);
-                    break;
+					result = ruleFactory.IRuleToStringConverter(true);
+					break;
 
                 default:
                 case "txt":
@@ -146,7 +157,10 @@ namespace FinalProject
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show($"An error has occured while saving Rule Preset File.\nTarget Path: {fileName}\nException: {e}\nDetails: {e.Message}", e.ToString(), MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show($"An error has occured while saving Rule Preset File.\nTarget Path: {fileName}\nException: {e}\nDetails: {e.Message}",
+                                    e.ToString(),
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Error);
                     success = false;
                 }
                 finally
@@ -155,6 +169,7 @@ namespace FinalProject
                 }
 
             };
+			
             return success;
         }
     }

--- a/FinalProject/PresetProcessor.cs
+++ b/FinalProject/PresetProcessor.cs
@@ -1,0 +1,131 @@
+﻿using Contract;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Windows;
+
+namespace FinalProject
+{
+    public static class PresetProcessor
+    {
+        public static List<IRule> ReadPresetFile(OpenFileDialog target, RuleFactory ruleFactory, out bool success)
+        {
+            success = false;
+            string fileName = target.FileName;
+            if (fileName == "") return new List<IRule>();
+
+            string extension = Path.GetExtension(fileName).ToLower();
+            if (extension != "") extension = extension.Substring(1);
+
+            List<IRule> newRuleList = new List<IRule>();
+            // Load rule preset files with the following file types:
+            switch (extension)
+            {
+                // JSON RULE PRESET FILE
+                case "json":
+                    try
+                    {
+                        string rawJson = File.ReadAllText(fileName);
+                        List<RuleDeserializeTemplate>? deserializedRules = JsonSerializer.Deserialize<List<RuleDeserializeTemplate>>(rawJson);
+
+                        if (deserializedRules != null)
+                        {
+                            //newRuleList = ruleList;
+                            foreach (RuleDeserializeTemplate ruleTemplate in deserializedRules)
+                            {
+                                string rawRule = $"{ruleTemplate.Name} {ruleTemplate.Config}";
+                                Debug.WriteLine(rawRule);
+                                newRuleList.Add(ruleFactory.StringToIRuleConverter(rawRule));
+                            }
+                            success = true;
+                        }
+                        /*
+                        else
+                        {
+                            MessageBox.Show("Deserialized list is null.");
+                        }
+                        */
+                    } 
+                    catch (Exception e)
+                    {
+                        MessageBox.Show($"Unable to deserialize JSON Preset.\n\n{e.Message}", e.ToString(), MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                    break;
+
+                // RAW RULE PRESET FILE
+                case "txt":
+                    List<string> fileContent = new List<string>();
+                    try
+                    {
+                        fileContent = new List<string>(File.ReadAllLines(fileName));
+                        success = true;
+                    }
+                    catch (Exception e)
+                    {
+                        MessageBox.Show("Rule file not found", e.ToString(), MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+
+                    foreach (string line in fileContent)
+                    {
+                        newRuleList.Add(ruleFactory.StringToIRuleConverter(line));
+                    }
+                    break;
+                
+                default:
+                    MessageBox.Show($"Unsupported file type ({extension})", "Rule Preset Reader", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    break;
+            }
+
+            return newRuleList;
+        }
+
+        public static bool WritePresetFile(SaveFileDialog target, RuleFactory ruleFactory)
+        {
+            string fileName = target.FileName;
+            if (fileName == "") return false;
+
+            string extension = Path.GetExtension(fileName).ToLower();
+            if (extension != "") extension = extension.Substring(1);
+
+            string result = "";
+            // Save rule preset file in the following file types:
+            switch (extension)
+            {
+                case "json":
+                    result = ruleFactory.IRuleToStringConverter(true);
+                    break;
+
+                default:
+                case "txt":
+                    result = ruleFactory.IRuleToStringConverter();
+                    break;
+            }
+
+            byte[] buffer = new UTF8Encoding().GetBytes(result);
+
+            bool success = true;
+            using (FileStream fs = File.Create(fileName, buffer.Length))
+            {
+                try
+                {
+                    fs.Write(buffer, 0, buffer.Length);
+                }
+                catch (Exception e)
+                {
+                    MessageBox.Show($"An error has occured while saving Rule Preset File.\nTarget Path: {fileName}\nException: {e}\nDetails: {e.Message}", e.ToString(), MessageBoxButton.OK, MessageBoxImage.Error);
+                    success = false;
+                }
+                finally
+                {
+                    fs.Close();
+                }
+                
+            };
+            return success;
+        }
+    }
+}

--- a/FinalProject/RawToRenamedConverter.cs
+++ b/FinalProject/RawToRenamedConverter.cs
@@ -18,6 +18,7 @@ namespace FinalProject
 			
 			Factory.FileName = fileName;
 			Factory.FileIndex = fileIndex;
+			
 			return Factory.Parse();
 		}
 

--- a/FinalProject/RuleFactory.cs
+++ b/FinalProject/RuleFactory.cs
@@ -58,7 +58,10 @@ namespace FinalProject
 			}
 			catch (KeyNotFoundException)
 			{
-				MessageBox.Show("Rule " + inputStr.Split(' ')[0] + " not found!", "StringToIRuleConverter", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+				MessageBox.Show("Rule " + inputStr.Split(' ')[0] + " not found!",   // Text
+								"StringToIRuleConverter",                           // Caption
+								MessageBoxButton.OK,                                // Button
+								MessageBoxImage.Exclamation);                       // Icon
 				return null;
 			}
 		}
@@ -67,6 +70,7 @@ namespace FinalProject
         public IRule? StringToIRuleConverter(string inputStr, out bool found)
         {
 			found = false;
+			
             try
             {
                 IRule? newIRule = rulePrototypes[inputStr.Split(' ')[0]].Clone() as IRule;
@@ -75,10 +79,7 @@ namespace FinalProject
 				found = true;
                 return newIRule;
             }
-            catch (KeyNotFoundException)
-            {
-            }
-			return null;
+            catch (KeyNotFoundException) { return null; }
         }
 
         // Reverse conversion
@@ -88,7 +89,10 @@ namespace FinalProject
 			{
 				string jsonContent = JsonSerializer.Serialize(_ruleList);
 				return jsonContent;
-			} else
+			}
+			
+			// .txt
+			else
 			{
 				string rawContent = "";
 				foreach (IRule rule in _ruleList)
@@ -112,8 +116,8 @@ namespace FinalProject
 
 
 
-		public string FileName { set { _fileName = value; } }
-		public int FileIndex { set { _fileIndex = value; } }
+		public string FileName { set => _fileName = value; }
+		public int FileIndex { set => _fileIndex = value; }
 
 		public string Parse()
 		{

--- a/FinalProject/RuleFactory.cs
+++ b/FinalProject/RuleFactory.cs
@@ -58,10 +58,28 @@ namespace FinalProject
 			}
 			catch (KeyNotFoundException)
 			{
-				MessageBox.Show("Rule " + inputStr.Split(' ')[0] + " not found!");
+				MessageBox.Show("Rule " + inputStr.Split(' ')[0] + " not found!", "StringToIRuleConverter", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 				return null;
 			}
 		}
+
+        // Overload of StringToIRuleConverter (No message box version)
+        public IRule? StringToIRuleConverter(string inputStr, out bool found)
+        {
+			found = false;
+            try
+            {
+                IRule? newIRule = rulePrototypes[inputStr.Split(' ')[0]].Clone() as IRule;
+
+                newIRule!.Parse = inputStr;
+				found = true;
+                return newIRule;
+            }
+            catch (KeyNotFoundException)
+            {
+            }
+			return null;
+        }
 
         // Reverse conversion
         public string IRuleToStringConverter(bool toJsonFormat = false)

--- a/FinalProject/RuleFactory.cs
+++ b/FinalProject/RuleFactory.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Windows;
+using System.Text.Json;
 
 namespace FinalProject
 {
@@ -59,6 +60,26 @@ namespace FinalProject
 			{
 				MessageBox.Show("Rule " + inputStr.Split(' ')[0] + " not found!");
 				return null;
+			}
+		}
+
+        // Reverse conversion
+        public string IRuleToStringConverter(bool toJsonFormat = false)
+		{
+			if (toJsonFormat)
+			{
+				string jsonContent = JsonSerializer.Serialize(_ruleList);
+				return jsonContent;
+			} else
+			{
+				string rawContent = "";
+				foreach (IRule rule in _ruleList)
+				{
+					string name = rule.Name;
+					string cfg = rule.Config;
+					rawContent += $"{name} {cfg}\n";
+				}
+				return rawContent;
 			}
 		}
 		

--- a/LowerCaseRemoveSpacesRule/LowerCaseRemoveSpaces.cs
+++ b/LowerCaseRemoveSpacesRule/LowerCaseRemoveSpaces.cs
@@ -17,9 +17,6 @@ namespace LowerCaseRemoveSpacesRule
 			return origin;
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/OneSpaceRule/OneSpace.cs
+++ b/OneSpaceRule/OneSpace.cs
@@ -15,9 +15,6 @@ namespace OneSpaceRule
 			return (string.Join(" ", inp.Split(" ", StringSplitOptions.RemoveEmptyEntries)));
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/PascalCaseRule/PascalCase.cs
+++ b/PascalCaseRule/PascalCase.cs
@@ -19,9 +19,6 @@ namespace PascalCaseRule
 			return string.Join(string.Empty, words);
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/RemoveSpecialCharsRule/RemoveSpecialChars.cs
+++ b/RemoveSpecialCharsRule/RemoveSpecialChars.cs
@@ -67,9 +67,6 @@ namespace RemoveSpecialCharsRule
 			return result.ToString();
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/RemoveSurroundingSpacesRule/RemoveSurroundingSpaces.cs
+++ b/RemoveSurroundingSpacesRule/RemoveSurroundingSpaces.cs
@@ -15,9 +15,6 @@ namespace RemoveSurroundingSpacesRule
 			return inp.Trim();
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }

--- a/ReplaceRule/Replace.cs
+++ b/ReplaceRule/Replace.cs
@@ -27,9 +27,6 @@ namespace ReplaceRule
 			return (origin.Replace(From, To));
 		}
 
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
+		public object Clone() => MemberwiseClone();
 	}
 }


### PR DESCRIPTION
Although this branch changes some of the core functions, they will not affect existing Rules.

static class `PresetProcessor` is added. The syntax for each of its functions is as follows:
```C#
// OpenFileDialog containing open target, RuleFactory instance, is method ran successfully?
// Return value:  List<IRule>
static List<IRule> ReadPresetFile(OpenFileDialog target, RuleFactory ruleFactory, out bool success);

// SaveFileDialog containing save target, RuleFactory instance
// Return value: bool (indicating whether or not the method ran successfully)
static bool WritePresetFile(SaveFileDialog target, RuleFactory ruleFactory);
```
`ReadPresetFile` loads existing preset files (`txt` and `json` for now) and interpret them into rules.
`WritePresetFile` saves user's current rule configurations.

This branch also summarizes the amount of "Rule not found" messages into 1 message box since it can be annoying.
If it's not necessary, merge [this commit](https://github.com/itsdmd/CS202-Final/commit/30e6ebe85b27d07683e0acce1c1208f8385ec140) instead.